### PR TITLE
Added list of valid resources if invalid resource is given

### DIFF
--- a/lib/locomotive/wagon.rb
+++ b/lib/locomotive/wagon.rb
@@ -166,7 +166,7 @@ module Locomotive
     protected
     def self.validate_resources(resources, writers_or_readers)
       return if resources.nil?
-      valid_resources = writers_or_readers.map { |thing| thing.to_s.demodulize.gsub(/Writer$|Reader$/, '').downcase } 
+      valid_resources = writers_or_readers.map { |thing| thing.to_s.demodulize.gsub(/Writer$|Reader$/, '').underscore } 
       resources.each do |resource|
         raise ArgumentError, "'#{resource}' resource not recognized. Valid resources are #{valid_resources.join(', ')}." unless valid_resources.include?(resource)
       end


### PR DESCRIPTION
If pushing an invalid resource name, the failure message will now tell which resources are valid.
