### PR TITLE
Add an exception in link_to tag

### DIFF
--- a/lib/locomotive/wagon/liquid/errors.rb
+++ b/lib/locomotive/wagon/liquid/errors.rb
@@ -5,6 +5,8 @@ module Locomotive
 
       class PageNotTranslated < ::Liquid::Error; end
 
+      class ContentTypeNotTranslated < ::Liquid::Error; end
+
       class UnknownConditionInScope < ::Liquid::Error; end
     end
   end

--- a/lib/locomotive/wagon/liquid/tags/link_to.rb
+++ b/lib/locomotive/wagon/liquid/tags/link_to.rb
@@ -103,6 +103,10 @@ module Locomotive
             fullpath = "#{::I18n.locale}/#{fullpath}" if ::I18n.locale.to_s != mounting_point.default_locale.to_s
 
             if page.templatized?
+              if page.content_entry._slug.nil?
+                title = %{#{page.content_entry.content_type.name.singularize} "#{page.content_entry.send(page.content_entry.content_type.label_field_name)}"}
+                raise Liquid::PageNotTranslated.new(%{the #{title} slug is not translated in #{locale.upcase}})
+              end
               fullpath.gsub!(/(content[_-]type[_-]template|template)/, page.content_entry._slug)
             end
 


### PR DESCRIPTION
Add an exception in link_to tag when a content type slug is not translated in the current locale
