### PR TITLE
date generator is using minute instead of month

### DIFF
--- a/generators/content_type/data/%name%.yml.tt
+++ b/generators/content_type/data/%name%.yml.tt
@@ -11,7 +11,7 @@
 <% when 'boolean' -%>
     <%= field.name -%>: true # Or false
 <% when 'date' -%>
-    <%= field.name -%>: <%= Time.now.strftime('%Y/%M/%d') -%> # YYYY/MM/DD
+    <%= field.name -%>: <%= Time.now.strftime('%Y/%m/%d') -%> # YYYY/MM/DD
 <% when 'file' -%>
     <%= field.name -%>: null # Path to a file in the public/samples folder or to a remote and external file.
 <% when 'belongs_to' -%>


### PR DESCRIPTION
Currently generator is creating invalid dates. 

This is annoying if you try to perform any date filtering with sample data, as it breaks with "invalid date" error.
