### PR TITLE
Added simple conditional that adds or removes a colon based on content type's number of attributes

### DIFF
--- a/generators/content_type/data/%name%.yml.tt
+++ b/generators/content_type/data/%name%.yml.tt
@@ -1,5 +1,5 @@
 <% 4.times do |i| -%>
-- "Sample <%= i + 1 %>":
+- "Sample <%= i + 1 %>"<%= ':' if config[:fields].size > 1 %>
 <% config[:fields][1..-1].each do |field| -%>
 <% case field.type -%>
 <% when 'string' -%>


### PR DESCRIPTION
For Issue #135

If there is only one content type attribute, colon at the end of file at data/example.yml won't be generated so that users won't have to manually go in and remove them.

Simple conditional that returns a colon based on config[:fields].size was added.
