### PR TITLE
Parse deploy.yml with ERB to support ENV vars

### DIFF
--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -260,10 +260,12 @@ module Locomotive
         #
         def retrieve_connection_info(env, path)
           require 'active_support/core_ext/hash'
+          require 'erb'
           connection_info = nil
           begin
             path_to_deploy_file = File.join(path, 'config', 'deploy.yml')
-            connection_info = YAML::load(File.open(path_to_deploy_file).read)[env.to_s].with_indifferent_access
+            env_parsed_deploy_file = ERB.new(File.open(path_to_deploy_file).read).result
+            connection_info = YAML::load(env_parsed_deploy_file)[env.to_s].with_indifferent_access
 
             if connection_info[:ssl] && !connection_info[:host].start_with?('https')
               connection_info[:host] = 'https://' + connection_info[:host]


### PR DESCRIPTION
Rspecs pass, but I couldn't get them to fail in the first place. Not sure if it's due to the heavy use of VCR or what. If the change alone isn't acceptable, I'm happy to write a test under some guidance.
