### PR TITLE
Fix undefined method `any`

### DIFF
--- a/lib/locomotive/wagon/liquid/drops/content_types.rb
+++ b/lib/locomotive/wagon/liquid/drops/content_types.rb
@@ -24,6 +24,10 @@ module Locomotive
             self.collection
           end
 
+          def any
+            self.collection.any?
+          end
+
           def first
             self.collection.first
           end


### PR DESCRIPTION
According to the docs, we should be able to use `any` on a content_type drop:
http://doc.locomotivecms.com/references/api/objects/content-type

This PR adds support for `{{ contents.posts.any }}` in a wagon project.
