### PR TITLE
Add force polling option to wagon server

### DIFF
--- a/lib/locomotive/wagon.rb
+++ b/lib/locomotive/wagon.rb
@@ -108,7 +108,7 @@ module Locomotive
         end
 
         # listen_thread = Thread.new do
-        Locomotive::Wagon::Listen.instance.start(reader) if use_listen
+        Locomotive::Wagon::Listen.instance.start(reader, options) if use_listen
 
         server.start
         # end

--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -262,11 +262,17 @@ module Locomotive
         method_option :port, aliases: '-p', type: 'string', default: '3333', desc: 'The port of the Thin server'
         method_option :daemonize, aliases: '-d', type: 'boolean', default: false, desc: 'Run daemonized Thin server in the background'
         method_option :live_reload_port, aliases: '-l', type: 'string', default: false, desc: 'Include the Livereload javascript in each page'
+        method_option :force_polling, aliases: '-o', type: 'boolean', default: false, desc: 'Force polling of files for reload'
         method_option :force, aliases: '-f', type: 'boolean', default: false, desc: 'Stop the current daemonized Thin server if found before starting a new one'
         method_option :verbose, aliases: '-v', type: 'boolean', default: false, desc: 'display the full error stack trace if an error occurs'
         def serve(path = '.')
           parent_pid = Process.pid
           force_color_if_asked(options)
+
+          if options[:force_polling]
+            say "Listener polling is on."
+          end
+
           if check_path!(path)
             begin
               Locomotive::Wagon.serve(path, options)

--- a/lib/locomotive/wagon/listen.rb
+++ b/lib/locomotive/wagon/listen.rb
@@ -9,11 +9,11 @@ module Locomotive::Wagon
       @@instance = new
     end
 
-    def start(reader)
+    def start(reader, options)
       @reader = reader
 
       self.definitions.each do |definition|
-        self.apply(definition)
+        self.apply(definition, options)
       end
     end
 
@@ -29,7 +29,7 @@ module Locomotive::Wagon
 
     protected
 
-    def apply(definition)
+    def apply(definition, options)
       reloader = Proc.new do |modified, added, removed|
         resources = [*definition.last]
         names     = resources.map { |n| "\"#{n}\"" }.join(', ')
@@ -49,7 +49,7 @@ module Locomotive::Wagon
       path    = File.join(self.reader.mounting_point.path, definition.first)
       path    = File.expand_path(path)
 
-      listener = ::Listen.to(path, {only: filter, force_polling: true}, &reloader)
+      listener = ::Listen.to(path, {only: filter, force_polling: options[:force_polling]}, &reloader)
 
       # non blocking listener
       listener.start

--- a/lib/locomotive/wagon/listen.rb
+++ b/lib/locomotive/wagon/listen.rb
@@ -49,7 +49,7 @@ module Locomotive::Wagon
       path    = File.join(self.reader.mounting_point.path, definition.first)
       path    = File.expand_path(path)
 
-      listener = ::Listen.to(path, only: filter, &reloader)
+      listener = ::Listen.to(path, {only: filter, force_polling: true}, &reloader)
 
       # non blocking listener
       listener.start


### PR DESCRIPTION
This adds a `force_polling` (`-o`) option to the `wagon serve` command.

This was required for me to work locally on a wagon app being served from a mounted folder on a VM.

More discussion about using Listen over mounted file systems can be found at https://github.com/guard/listen/issues/57
