### PR TITLE
Allow custom css classes for link_to helper

### DIFF
--- a/lib/locomotive/wagon/liquid/tags/link_to.rb
+++ b/lib/locomotive/wagon/liquid/tags/link_to.rb
@@ -31,7 +31,14 @@ module Locomotive
                 label = super.html_safe
               end
 
-              %{<a href="#{path}">#{label}</a>}
+              if @_options['class']
+                css_classes = @_options['class'].gsub("'", '')
+                class_attr = " class=\"#{css_classes}\""
+              else
+                class_attr = ''
+              end
+
+              %{<a href="#{path}"#{class_attr}>#{label}</a>}
             end
           end
 

--- a/spec/fixtures/default/app/views/pages/events.liquid.haml
+++ b/spec/fixtures/default/app/views/pages/events.liquid.haml
@@ -59,5 +59,7 @@ position: 5
     %br
     {% assign another_song = contents.songs.last %}
     %strong {% link_to another_song, with: a-song-template %}
-
+    %br
+    {% link_to another_song, class: 'custom-class' %}
+    {% link_to another_song, class: 'custom-class-one custom-class-two' %}
 {% endblock %}

--- a/spec/integration/server/liquid_spec.rb
+++ b/spec/integration/server/liquid_spec.rb
@@ -64,6 +64,16 @@ describe Locomotive::Wagon::Server do
       last_response.body.should =~ /<a href="\/songs\/song-number-8">Song #8<\/a>/
     end
 
+    it "writes a link with a custom css class" do
+      get '/events'
+      last_response.body.should =~ /<a href="\/songs\/song-number-8" class="custom-class">Song #8<\/a>/
+    end
+
+    it "writes a link with multiple custom css classes" do
+      get '/events'
+      last_response.body.should =~ /<a href="\/songs\/song-number-8" class="custom-class-one custom-class-two">Song #8<\/a>/
+    end
+
   end
 
   describe 'scope & assigns' do


### PR DESCRIPTION
Add `class` option to `link_to` helper to allow custom css classes. References https://github.com/locomotivecms/engine/issues/743
