### PR TITLE
always start live reload on the default port

### DIFF
--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -261,7 +261,7 @@ module Locomotive
         method_option :host, aliases: '-h', type: 'string', default: '0.0.0.0', desc: 'The host (address) of the Thin server'
         method_option :port, aliases: '-p', type: 'string', default: '3333', desc: 'The port of the Thin server'
         method_option :daemonize, aliases: '-d', type: 'boolean', default: false, desc: 'Run daemonized Thin server in the background'
-        method_option :live_reload_port, aliases: '-l', type: 'string', default: false, desc: 'Include the Livereload javascript in each page'
+        method_option :live_reload_port, aliases: '-l', type: 'string', default: 35729, desc: 'Include the Livereload javascript in each page'
         method_option :force, aliases: '-f', type: 'boolean', default: false, desc: 'Stop the current daemonized Thin server if found before starting a new one'
         method_option :verbose, aliases: '-v', type: 'boolean', default: false, desc: 'display the full error stack trace if an error occurs'
         def serve(path = '.')


### PR DESCRIPTION
This is regarding issue #236 
