### PR TITLE
Require version.rb to avoid uninitialized constant

### DIFF
--- a/lib/locomotive/wagon.rb
+++ b/lib/locomotive/wagon.rb
@@ -1,3 +1,4 @@
+require_relative 'wagon/version'
 require_relative 'wagon/exceptions'
 
 module Locomotive


### PR DESCRIPTION
Not sure why this was removed as [part of the refactoring](https://github.com/locomotivecms/wagon/commit/f918767c4276e74043cfe82934206f686d5c3a16#diff-da38969b66cecf61d4762d540af3f0abL1), but I'm unable to run init, clone, etc in wagon-2.0.0.pre.alpha.3 built from current HEAD (@2e58216) without it.

**Full disclosure:** I'm a total locomotive newbie, so I may be missing something painfully obvious here, although it looks like [I'm not the only one](https://github.com/locomotivecms/wagon/issues/250) who has recently run into this `uninitialized constant Locomotive::Wagon::VERSION` error