### PR TITLE
extend regular expression to also match images with "." characters in the filename

### DIFF
--- a/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
@@ -4,7 +4,7 @@ module Locomotive::Wagon
 
   module AssetsConcern
 
-    ASSET_REGEX = /\/sites\/[0-9a-f]{24}\/(assets|pages|theme|content_entry[0-9a-f]{24})\/(([^;.]+)\/)*([a-zA-Z_\-0-9]+)\.([a-z]{2,3})/
+    REGEX = /\/sites\/[0-9a-f]{24}\/(assets|pages|theme|content_entry[0-9a-f]{24})\/(([^;.]+)\/)*([a-zA-Z_\-0-9.]+)\.([A-Za-z]{2,3})/
 
     # The content assets on the remote engine follows the format: /sites/<id>/assets/<type>/<file>
     # This method replaces these urls by their local representation. <type>/<file>
@@ -14,7 +14,7 @@ module Locomotive::Wagon
     def replace_asset_urls(content)
       return '' if content.blank?
 
-      content.force_encoding('utf-8').gsub(ASSET_REGEX) do |url|
+      content.force_encoding('utf-8').gsub(REGEX) do |url|
         filename = "#{$4}.#{$5}"
         folder = case $1
         when 'assets', 'pages'  then File.join('samples', $1)

--- a/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
@@ -4,6 +4,8 @@ module Locomotive::Wagon
 
   module AssetsConcern
 
+    ASSET_REGEX = /\/sites\/[0-9a-f]{24}\/(assets|pages|theme|content_entry[0-9a-f]{24})\/(([^;.]+)\/)*([a-zA-Z_\-0-9]+)\.([a-z]{2,3})/
+
     # The content assets on the remote engine follows the format: /sites/<id>/assets/<type>/<file>
     # This method replaces these urls by their local representation. <type>/<file>
     #
@@ -12,7 +14,7 @@ module Locomotive::Wagon
     def replace_asset_urls(content)
       return '' if content.blank?
 
-      content.force_encoding('utf-8').gsub(/\/sites\/[0-9a-f]{24}\/(assets|pages|theme|content_entry[0-9a-f]{24})\/(([^;.]+)\/)*([a-zA-Z_\-0-9]+)\.([a-z]{2,3})/) do |url|
+      content.force_encoding('utf-8').gsub(ASSET_REGEX) do |url|
         filename = "#{$4}.#{$5}"
         folder = case $1
         when 'assets', 'pages'  then File.join('samples', $1)

--- a/spec/unit/commands/pull_sub_commands/concerns/assets_concern_spec.rb
+++ b/spec/unit/commands/pull_sub_commands/concerns/assets_concern_spec.rb
@@ -1,0 +1,28 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+require 'locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern'
+
+describe Locomotive::Wagon::AssetsConcern do
+  describe "calling replace_asset_urls" do
+
+    let(:assets_concern) { Class.new { include Locomotive::Wagon::AssetsConcern } }
+    it "identifies the assets which should be downloaded when pulling" do
+
+      input = <<-INPUT
+        <td><img src="https://somedomain.com/sites/51277e8fc0864503db000007/assets/534d2a28e6439a92180009a6/UPPERCASE.CH.FILE.jpg"/></td>
+        <td><img src="https://somedomain.com/sites/51277e8fc0864503db000007/assets/532a8eeacf7727c1bb00012e/lowercase.ch.file.jpg" /></td>
+        <td><img src="https://somedomain.com/sites/51277e8fc0864503db000007/assets/532a8eeac086452e35000169/some_name.jpg" /></td>
+        <td><img src="https://somedomain.com/sites/51277e8fc0864503db000007/assets/532a8eeac086452e35000169/some_name.JPG" /></td>
+      INPUT
+
+      parsed_urls = []
+      input.force_encoding('utf-8').gsub(assets_concern::REGEX) do |url|
+        parsed_urls.push url
+      end
+
+      expect(parsed_urls.count).to eq(4)
+    end
+  end
+end


### PR DESCRIPTION
Hello @did 

When parsing asset urls from the content, the problem is that file urls like this one:
`https://somedomain.com/sites/51277e8fc0864503db000007/assets/532a8eeacf7727c1bb00012e/lowercase.ch.file.jpg` are cut down to `https://somedomain.com/sites/51277e8fc0864503db000007/assets/532a8eeacf7727c1bb00012e/lowercase.ch` which then leads to the following error message when pulling the pages:

`undefined local variable or method `binary' for #<Locomotive::Wagon::PullPagesCommand:0x007ff8a42379c8>`

I extended the regular expression and also added a small test to it.

Let me know what you think.

PS: Please note that when I ran the tests locally, the following test always failed:
Locomotive::Wagon::PushCommand#push unknown env creates a site and push the site. I assume it is connected to "No account found for john@doe.net or invalid credentials" which is mentioned in the beginning when running the tests.