### PR TITLE
Changed splitting and joining of filename

### DIFF
--- a/lib/locomotive/wagon/decorators/theme_asset_decorator.rb
+++ b/lib/locomotive/wagon/decorators/theme_asset_decorator.rb
@@ -37,7 +37,7 @@ module Locomotive
         # - memoize it because it will not change even if we change the filepath (or source)
         # - we keep the first extension and drop the others (.coffee, .scss, ...etc)
         @realname ||= if Sprockets.engine_extensions.include?(File.extname(filepath))
-          File.basename(filepath).split('.')[0..1].join('.')
+          File.basename(filepath).split('.')[0..-2].join('.')
         else
           File.basename(filepath)
         end


### PR DESCRIPTION
Some jquery libraries use namespacing like `jquery.pluginXy.js` and `jquery.pluginXy.css.scss` for their sass files. The old logic doesn't work with a . in the scss filename, as it returns `jquery.pluginXy` as filename, which then issues an "unsupported filetype" error.

This PR let it correctly return `jquery.pluginXy.css`