### PR TITLE
requires Gemfile extension gems to behave like Rails (and the engine)

### DIFF
--- a/lib/locomotive/wagon/commands/serve_command.rb
+++ b/lib/locomotive/wagon/commands/serve_command.rb
@@ -1,3 +1,5 @@
+require "bundler"
+
 module Locomotive::Wagon
 
   class ServeCommand < Struct.new(:path, :options, :shell)
@@ -70,7 +72,6 @@ module Locomotive::Wagon
       configure_logger
 
       subscribe_to_notifications
-
       Locomotive::Steam.configure do |config|
         config.mode         = :test
         config.adapter      = { name: :filesystem, path: File.expand_path(path) }
@@ -80,9 +81,9 @@ module Locomotive::Wagon
           require 'rack-livereload'
           config.middleware.insert_before Rack::Lint, Rack::LiveReload, live_reload_port: port
         end
-
         config.middleware.insert_before Rack::Lint, Locomotive::Wagon::Middlewares::ErrorPage
       end
+      Bundler.require(:default)
     end
 
     def daemonize


### PR DESCRIPTION
without this, if, for instance, you create a new gem with liquid extensions, it won't be loaded in wagon and your tags won't be found. I think it should be straightforward instead to add plugins to Wagon just like it is for the engine (Rails does this).