### PR TITLE
Fixed issue with empty content_assets

### DIFF
--- a/lib/locomotive/wagon/commands/pull_sub_commands/pull_content_assets_command.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/pull_content_assets_command.rb
@@ -3,7 +3,12 @@ module Locomotive::Wagon
   class PullContentAssetsCommand < PullBaseCommand
 
     def _pull
-      api_client.content_assets.all.each do |asset|
+      begin
+        all_content_assets = api_client.content_assets.all
+      rescue
+        all_content_assets = []
+      end
+      all_content_assets.each do |asset|
         write_content_asset(asset)
       end
     end

--- a/lib/locomotive/wagon/commands/push_sub_commands/push_content_assets_command.rb
+++ b/lib/locomotive/wagon/commands/push_sub_commands/push_content_assets_command.rb
@@ -41,9 +41,13 @@ module Locomotive::Wagon
 
     def remote_entities
       return @remote_entities if @remote_entities
-
       @remote_entities = {}.tap do |hash|
-        api_client.content_assets.all.each do |entity|
+        begin
+          all_content_assets = api_client.content_assets.all
+        rescue
+          all_content_assets = []
+        end
+        all_content_assets.each do |entity|
           hash[entity.full_filename] = entity
         end
       end


### PR DESCRIPTION
I cannot pull or push because wagon always crashes because `content_assets` doesn't have the method `all`. This patch fixes the problem