### PR TITLE
Fix an issue on windows when pushing theme/content assets

### DIFF
--- a/lib/locomotive/wagon/decorators/content_asset_decorator.rb
+++ b/lib/locomotive/wagon/decorators/content_asset_decorator.rb
@@ -10,17 +10,22 @@ module Locomotive
       end
 
       def source
-        Locomotive::Coal::UploadIO.new(filepath, nil, filename)
+        Locomotive::Coal::UploadIO.new(_readfile(filepath), nil, filename)
       end
 
       def checksum
-        Digest::MD5.hexdigest(File.read(filepath))
+        Digest::MD5.hexdigest(_readfile(filepath) { |io| io.read })
       end
 
       def filename
         File.basename(filepath)
       end
 
+      private
+      
+      def _readfile(path, &block)
+        File.open(path, 'rb', &block)
+      end
     end
 
   end

--- a/lib/locomotive/wagon/decorators/theme_asset_decorator.rb
+++ b/lib/locomotive/wagon/decorators/theme_asset_decorator.rb
@@ -21,7 +21,7 @@ module Locomotive
       end
 
       def source
-        Locomotive::Coal::UploadIO.new(filepath, nil, realname)
+        Locomotive::Coal::UploadIO.new(_readfile(filepath), nil, realname)
       end
 
       def priority
@@ -33,7 +33,7 @@ module Locomotive
       end
 
       def checksum
-        Digest::MD5.hexdigest(File.read(filepath))
+        Digest::MD5.hexdigest(_readfile(filepath) { |io| io.read })
       end
 
       # - memoize it because it will not change even if we change the filepath (or source)
@@ -70,6 +70,10 @@ module Locomotive
         if new_extension = EXTENSIONS_TABLE[extension]
           File.basename(filename, extension) + new_extension
         end
+      end
+      
+      def _readfile(path, &block)
+        File.open(path, 'rb', &block)
       end
 
     end


### PR DESCRIPTION
On Windows ruby requires binary files to be opened with FileMode
binary to supress EOL <-> CRLF conversions.

Relevant docs:
http://ruby-doc.org/core-2.0.0/IO.html#method-c-new-label-Open+Mode

This fix ensures content and theme assets deploy to an engine without
being cut off or mangled by eol conversion & it ensures checksum
comparisons of the assets are done against the whole file not just
part.