### PR TITLE
feature: per-site asset host

### DIFF
--- a/lib/locomotive/wagon/commands/pull_sub_commands/pull_site_command.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/pull_site_command.rb
@@ -3,7 +3,7 @@ module Locomotive::Wagon
   class PullSiteCommand < PullBaseCommand
 
     def _pull
-      attributes = current_site.attributes.slice('name', 'locales', 'domains', 'timezone', 'seo_title', 'meta_keywords', 'meta_description', 'picture_thumbnail_url', 'metafields', 'metafields_schema', 'metafields_ui', 'robots_txt')
+      attributes = current_site.attributes.slice('name', 'locales', 'domains', 'timezone', 'seo_title', 'meta_keywords', 'meta_description', 'picture_thumbnail_url', 'metafields', 'metafields_schema', 'metafields_ui', 'robots_txt', 'asset_host')
 
       locales.each_with_index do |locale, index|
         if index == 0

--- a/lib/locomotive/wagon/decorators/site_decorator.rb
+++ b/lib/locomotive/wagon/decorators/site_decorator.rb
@@ -34,14 +34,14 @@ module Locomotive
         end
       end
 
-      %i(robots_txt timezone seo_title meta_keywords meta_description).each do |name|
+      %i(robots_txt timezone seo_title meta_keywords meta_description asset_host).each do |name|
         define_method(name) do
           self[name]
         end
       end
 
       def __attributes__
-        %i(name handle robots_txt locales timezone seo_title meta_keywords meta_description picture metafields_schema metafields metafields_ui)
+        %i(name handle robots_txt locales timezone seo_title meta_keywords meta_description picture metafields_schema metafields metafields_ui asset_host)
       end
 
       def edited?
@@ -53,7 +53,7 @@ module Locomotive
     class UpdateSiteDecorator < SiteDecorator
 
       def __attributes__
-        %i(picture locales metafields_schema metafields metafields_ui)
+        %i(picture locales metafields_schema metafields metafields_ui asset_host)
       end
 
     end


### PR DESCRIPTION
These are the changes to the ```wagon``` library that are needed to allow for per-site asset hosts.

This augments the default behavior of setting a single asset host at the ```engine``` level.

```engine```, ```steam```, and ```wagon``` all require changes for this feature to work:

- https://github.com/interhive/engine/tree/feature-per-site-asset-host
- https://github.com/interhive/steam/tree/feature-per-site-asset-host
- https://github.com/interhive/wagon/tree/feature-per-site-asset-host

Please review and let me know if I need to make any changes.

Thanks,
Chris