### PR TITLE
Env vars for serve

### DIFF
--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -273,9 +273,9 @@ module Locomotive
 
         desc 'serve [PATH]', 'Serve a site from the file system'
         option :host, aliases: '-h', type: 'string', default: '0.0.0.0', desc: 'The host (address) of the Thin server'
-        option :port, aliases: '-p', type: 'string', default: '3333', desc: 'The port of the Thin server'
+        option :port, aliases: '-p', type: 'string', default: (ENV['WAGON_PORT'] || '3333'), desc: 'The port of the Thin server'
         option :daemonize, aliases: '-d', type: 'boolean', default: false, desc: 'Run daemonized Thin server in the background'
-        option :live_reload_port, aliases: '-l', type: 'string', default: '35729', desc: 'The port the LiveReload javascript lib needs to listen for changes (35729 by default)'
+        option :live_reload_port, aliases: '-l', type: 'string', default: (ENV['WAGON_LIVE_RELOAD_PORT'] || '35729'), desc: 'The port the LiveReload javascript lib needs to listen for changes (35729 by default)'
         option :force, aliases: '-f', type: 'boolean', default: false, desc: 'Stop the current daemonized Thin server if found before starting a new one'
         option :verbose, aliases: '-v', type: 'boolean', default: false, desc: 'Display the full error stack trace if an error occurs'
         option :debug, type: 'boolean', default: false, desc: 'Display some debugging information (rack middleware stack)'

--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -275,7 +275,7 @@ module Locomotive
         option :host, aliases: '-h', type: 'string', default: '0.0.0.0', desc: 'The host (address) of the Thin server'
         option :port, aliases: '-p', type: 'string', default: (ENV['WAGON_PORT'] || '3333'), desc: 'The port of the Thin server'
         option :daemonize, aliases: '-d', type: 'boolean', default: false, desc: 'Run daemonized Thin server in the background'
-        option :live_reload_port, aliases: '-l', type: 'string', default: (ENV['WAGON_LIVE_RELOAD_PORT'] || '35729'), desc: 'The port the LiveReload javascript lib needs to listen for changes'
+        option :live_reload_port, aliases: '-l', type: 'string', default: (ENV['WAGON_LIVERELOAD_PORT'] || '35729'), desc: 'The port the LiveReload javascript lib needs to listen for changes'
         option :force, aliases: '-f', type: 'boolean', default: false, desc: 'Stop the current daemonized Thin server if found before starting a new one'
         option :verbose, aliases: '-v', type: 'boolean', default: false, desc: 'Display the full error stack trace if an error occurs'
         option :debug, type: 'boolean', default: false, desc: 'Display some debugging information (rack middleware stack)'

--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -275,7 +275,7 @@ module Locomotive
         option :host, aliases: '-h', type: 'string', default: '0.0.0.0', desc: 'The host (address) of the Thin server'
         option :port, aliases: '-p', type: 'string', default: (ENV['WAGON_PORT'] || '3333'), desc: 'The port of the Thin server'
         option :daemonize, aliases: '-d', type: 'boolean', default: false, desc: 'Run daemonized Thin server in the background'
-        option :live_reload_port, aliases: '-l', type: 'string', default: (ENV['WAGON_LIVE_RELOAD_PORT'] || '35729'), desc: 'The port the LiveReload javascript lib needs to listen for changes (35729 by default)'
+        option :live_reload_port, aliases: '-l', type: 'string', default: (ENV['WAGON_LIVE_RELOAD_PORT'] || '35729'), desc: 'The port the LiveReload javascript lib needs to listen for changes'
         option :force, aliases: '-f', type: 'boolean', default: false, desc: 'Stop the current daemonized Thin server if found before starting a new one'
         option :verbose, aliases: '-v', type: 'boolean', default: false, desc: 'Display the full error stack trace if an error occurs'
         option :debug, type: 'boolean', default: false, desc: 'Display some debugging information (rack middleware stack)'


### PR DESCRIPTION
I'm running wagon with cloud9 in a docker container. In this scenario, the most critical part, is the livereload port, although being able to also sets wagon serve port increases consistency.

Specify ports for the running container allows many users to share the same server and is very easy to do with docker run -p option, for example: `-p 45729:35729 -p 45321:3333`.

The `-p 45321:3333` is a bit confusing when accessing the cloud9 IDE, the users will see that the default serve port is 3333, but it have to use the 45321 port to see the preview. Confusing, but usable by many users.

The `-p 45729:35729` works, but makes livereload non functional, since wagon will serve the preview using the 35729 port, a port that the user can't connect. The ideal in this case is use two options for docker run: `-p 45729:45729 -e WAGON_LIVERELOAD_PORT=45729`.

This patch allows to specify the desired port for wagon serve and the livereload serve, allowing the user to start `bundle exec wagon serve` without the need to specify any other option. So for example, for the given docker run options `-p 45729:45729 -p 4444:4444 -e WAGON_PORT=4444 -e WAGON_LIVERELOAD_PORT=45729`, I will see the following output for `bundle exec wagon help serve`:

```bash
...
  -p, [--port=PORT]                          # The port of the Thin server
                                             # Default: 4444
...
  -l, [--live-reload-port=LIVE_RELOAD_PORT]  # The port the LiveReload javascript lib needs to listen for changes
                                             # Default: 45729
...
```

This allow total control of wagon/livereload default ports in a containerized world.