### PR TITLE
When using `deploy -d` option, do not warn when pushing to development

### DIFF
--- a/lib/locomotive/wagon/commands/push_command.rb
+++ b/lib/locomotive/wagon/commands/push_command.rb
@@ -40,7 +40,7 @@ module Locomotive::Wagon
 
       # Ask for a confirmation (Warning) if we deploy with the -d option
       # since it alters content on the remote engine
-      if options[:data]
+      if options[:data] && self.env != 'development'
         return unless ask_for_performing("Warning! You're about to deploy data which will alter the content of your site.")
       end
 


### PR DESCRIPTION
Turns out the yes/no question for `deploy -d` option is a little bit monotonous in development environment. Lets skip if for development env.