### PR TITLE
Added data folder to gitignore

### DIFF
--- a/generators/blank/.gitignore
+++ b/generators/blank/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 config/deploy.yml
 public/stylesheets/bundle.css
 public/javascripts/bundle.js
+data/


### PR DESCRIPTION
I think that `data` folder should be added to `.gitignore` by default as if its not, it can cause exposure of private data in some cases. For example:
1. We have a metafield with a private API key saved in metafields.
2. We sync local content with live content
3. We push to github

The issue this creates is that in the file called `site.json` are printed the values of the metafields. Pushing them to github can expose a key that should be kept private.