### PR TITLE
Fix encoding issue

### DIFF
--- a/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
@@ -69,7 +69,10 @@ module Locomotive::Wagon
       if binary = get_asset_binary(url)
         FileUtils.mkdir_p(File.dirname(filepath))
 
-        (binary_file = Tempfile.new(File.basename(filepath))).write(binary)
+        # Tempfiles are in ascii-mode per default on linux. Therefore
+        # we need to switch to binmode.
+        puts "Write file with patched version of #{__FILE__}: #{filepath}"
+        (binary_file = Tempfile.new(File.basename(filepath)).binmode).write(binary)
 
         find_unique_filepath(filepath, binary_file).tap do |filepath|
           File.open(filepath, 'wb') { |f| f.write(binary) }

--- a/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
@@ -69,9 +69,6 @@ module Locomotive::Wagon
       if binary = get_asset_binary(url)
         FileUtils.mkdir_p(File.dirname(filepath))
 
-        # Tempfiles are in ascii-mode per default on linux. Therefore
-        # we need to switch to binmode.
-        puts "Write file with patched version of #{__FILE__}: #{filepath}"
         (binary_file = Tempfile.new(File.basename(filepath)).binmode).write(binary)
 
         find_unique_filepath(filepath, binary_file).tap do |filepath|


### PR DESCRIPTION
I found a very strange problem if I used wagon sync on linux systems. This problem causes the following error message when using `bundle exec wagon sync <environment>`:

> \# Error description:
> invalid byte sequence in US-ASCII

I've found that the Tempfile is not running in binary mode as default! I don't know why this is the case, as it makes no sense in my opinion. You can read the following article for details:

http://vaidehijoshi.github.io/blog/2015/10/06/fleeting-filing-with-ruby-tempfile/

I've changed the call and .. voila .. it works now. :)

This "problem" seems to be linux related as it does not happen on a mac. You can use a ruby:2.6.3 docker container for testing.

