### PR TITLE
typo in webpack common loading for prod config

### DIFF
--- a/generators/blank/app/assets/webpack.prod.js
+++ b/generators/blank/app/assets/webpack.prod.js
@@ -1,5 +1,5 @@
 const merge = require('webpack-merge');
-const common = require('./webpack.config.js');
+const common = require('./webpack.common.js');
 const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = merge(common, {


### PR DESCRIPTION
Hello.
Just a small name typo that prevents yarn build:prod from working (out of the box) in the blank website template
👍 For Locomotive V4
Thx!!