### PR TITLE
Fixed frozen string error

### DIFF
--- a/lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb
+++ b/lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb
@@ -87,7 +87,7 @@ module Locomotive::Wagon
 
     def compress_and_minify(entity)
       begin
-        sprockets_env[entity.short_relative_url].to_s
+        "#{sprockets_env[entity.short_relative_url]}"
       rescue Exception => e
         instrument :warning, message: "Unable to compress and minify it, error: #{e.message}"
         # use the original file instead


### PR DESCRIPTION
Ruby 2.7.1 and bundler 2.1.4 here

After a necessary `bundle update` 2 specs complained - and quite loudly so if I daresay, about 

```ruby
Bundler version 2.1.4# ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:57:in `gsub!'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:57:in `replace_assets!'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:46:in `block in precompile'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:42:in `tap'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:42:in `precompile'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_theme_assets_command.rb:21:in `persist'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:34:in `block in _push'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:30:in `each'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:30:in `_push'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:25:in `block in _push_with_timezone'
     # /Users/robert/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/core_ext/time/zones.rb:66:in `use_zone'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:24:in `_push_with_timezone'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:18:in `block in push'
     # /Users/robert/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `block in instrument'
     # /Users/robert/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/notifications/instrumenter.rb:23:in `instrument'
     # /Users/robert/.rvm/gems/ruby-2.7.1/gems/activesupport-5.2.4.4/lib/active_support/notifications.rb:168:in `instrument'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:50:in `instrument'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:16:in `push'
     # ./lib/locomotive/wagon/commands/push_sub_commands/push_base_command.rb:12:in `push'
     # ./lib/locomotive/wagon/commands/push_command.rb:65:in `block in _push'
     # ./lib/locomotive/wagon/commands/push_command.rb:94:in `block in each_resource'
     # ./lib/locomotive/wagon/commands/push_command.rb:87:in `each'
     # ./lib/locomotive/wagon/commands/push_command.rb:87:in `each_resource'
     # ./lib/locomotive/wagon/commands/push_command.rb:64:in `_push'
     # ./lib/locomotive/wagon/commands/push_command.rb:51:in `push'
     # ./spec/integration/commands/push_command_spec.rb:20:in `block (3 levels) in <top (required)>'
     # ./spec/integration/commands/push_command_spec.rb:48:in `block (5 levels) in <top (required)>'
```
I am aware that this solution might not really address all concerned issues, but at least it will get you informed about the problem.

BTW my goal is to get rid of the Faraday warnings