### PR TITLE
Ruby 3.2 deprecation crashes wagon/steam

### DIFF
--- a/lib/locomotive/wagon/cli.rb
+++ b/lib/locomotive/wagon/cli.rb
@@ -21,7 +21,7 @@ module Locomotive
 
           path = path == '.' ? Dir.pwd : File.expand_path(path)
 
-          site_or_deploy_file = File.exists?(File.join(path, 'config', 'site.yml')) || File.exists?(File.join(path, 'config', 'deploy.yml'))
+          site_or_deploy_file = File.exist?(File.join(path, 'config', 'site.yml')) || File.exist?(File.join(path, 'config', 'deploy.yml'))
 
           (site_or_deploy_file ? path : nil).tap do |_path|
             if _path.nil?

--- a/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/concerns/assets_concern.rb
@@ -50,7 +50,7 @@ module Locomotive::Wagon
     private
 
     def find_unique_filepath(filepath, binary_file, index = 1)
-      if File.exists?(filepath) && File.file?(filepath)
+      if File.exist?(filepath) && File.file?(filepath)
         # required because we need to make sure we use the content of file from its start
         binary_file.rewind
 

--- a/lib/locomotive/wagon/commands/pull_sub_commands/pull_base_command.rb
+++ b/lib/locomotive/wagon/commands/pull_sub_commands/pull_base_command.rb
@@ -51,7 +51,7 @@ module Locomotive::Wagon
 
       folder = File.dirname(_filepath)
 
-      FileUtils.mkdir_p(folder) unless File.exists?(folder)
+      FileUtils.mkdir_p(folder) unless File.exist?(folder)
 
       File.open(_filepath, mode) do |file|
         if content
@@ -66,7 +66,7 @@ module Locomotive::Wagon
 
     def reset_file(filepath)
       _filepath = File.join(path, filepath)
-      FileUtils.rm(_filepath) if File.exists?(_filepath)
+      FileUtils.rm(_filepath) if File.exist?(_filepath)
     end
 
     def instrument_base_name

--- a/lib/locomotive/wagon/commands/serve_command.rb
+++ b/lib/locomotive/wagon/commands/serve_command.rb
@@ -46,7 +46,7 @@ module Locomotive::Wagon
     end
 
     def stop(force = false)
-      unless File.exists?(server_pid_file)
+      unless File.exist?(server_pid_file)
         shell.say "No Wagon server is running.", :red
         return
       end
@@ -140,7 +140,7 @@ module Locomotive::Wagon
 
         filepath = File.join(File.expand_path(path), 'app', 'views', 'pages', fullpath + (locale != default_locale ? ".#{locale}" : '') + '.liquid')
 
-        message = if File.exists?(filepath)
+        message = if File.exist?(filepath)
           "[Warning]".red + ' by default and unless you override the slug in the YAML header of your page, Wagon will replace underscores by dashes in your page slug. Try this instead: ' + fullpath.dasherize.light_white
         else
           "[Tip]".light_white + " add a new page in your Wagon site at this location: " + filepath.light_white

--- a/lib/locomotive/wagon/decorators/site_decorator.rb
+++ b/lib/locomotive/wagon/decorators/site_decorator.rb
@@ -41,7 +41,7 @@ module Locomotive
 
       def picture
         picture_path = __getobj__.picture
-        if picture_path && File.exists?(picture_path)
+        if picture_path && File.exist?(picture_path)
           Locomotive::Coal::UploadIO.new(picture_path, nil, 'icon.png')
         else
           nil

--- a/lib/locomotive/wagon/generators/relationship.rb
+++ b/lib/locomotive/wagon/generators/relationship.rb
@@ -17,11 +17,11 @@ module Locomotive
         argument :target_path # path to the site
 
         def content_types_must_exist
-          unless File.exists?(File.join(destination_root, source_path))
+          unless File.exist?(File.join(destination_root, source_path))
             fail Thor::Error, "The #{source} content type does not exist"
           end
 
-          unless File.exists?(File.join(destination_root, target_path))
+          unless File.exist?(File.join(destination_root, target_path))
             fail Thor::Error, "The #{target} content type does not exist"
           end
         end

--- a/lib/locomotive/wagon/generators/section.rb
+++ b/lib/locomotive/wagon/generators/section.rb
@@ -56,7 +56,7 @@ module Locomotive
         end
 
         def create_javascript_file
-          if File.exists?(sections_js_path)
+          if File.exist?(sections_js_path)
             js_class_name = @options[:type].classify
             file_path     = File.join(sections_js_path, @options[:type])
 
@@ -73,7 +73,7 @@ export { default as #{js_class_name} } from './#{@options[:type]}';
         end
 
         def create_stylesheet_file
-          if File.exists?(sections_css_path)
+          if File.exist?(sections_css_path)
             css_class_name  = "#{@options[:type].dasherize}-section"
             file_path       = File.join(sections_css_path, @options[:type])
 

--- a/lib/locomotive/wagon/generators/site.rb
+++ b/lib/locomotive/wagon/generators/site.rb
@@ -108,7 +108,7 @@ module Locomotive
                 name:         template.name,
                 description:  template.description,
                 path:         path,
-                icon:         icon && File.exists?(icon) ? icon : nil,
+                icon:         icon && File.exist?(icon) ? icon : nil,
                 options:      class_options_to_json(template)
               }
             end.to_json

--- a/spec/integration/commands/sync_command_spec.rb
+++ b/spec/integration/commands/sync_command_spec.rb
@@ -36,10 +36,10 @@ describe Locomotive::Wagon::SyncCommand do
 
     it 'exports the content of a site, content entries and pages' do
       is_expected.not_to eq nil
-      expect(File.exists?(File.join(data_path, 'site.json'))).to eq true
-      expect(File.exists?(File.join(data_path, 'content_entries', 'bands.yml'))).to eq true
+      expect(File.exist?(File.join(data_path, 'site.json'))).to eq true
+      expect(File.exist?(File.join(data_path, 'content_entries', 'bands.yml'))).to eq true
       %w(fr nb en).each do |locale|
-        expect(File.exists?(File.join(data_path, 'pages', locale, 'index.json'))).to eq true
+        expect(File.exist?(File.join(data_path, 'pages', locale, 'index.json'))).to eq true
       end
     end
 


### PR DESCRIPTION
"File.exists?" as been deprecated in ruby 3.2 and was replaced with "File.exist?"